### PR TITLE
Create initial project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# smart-host
+# Smart Host
+
+Skeleton project demonstrating a simple layered architecture.
+
+```
+smart-host/
+├── src/
+│   └── smart_host/
+│       ├── domain/          # business models
+│       ├── service/         # service layer operating on models
+│       ├── infrastructure/  # persistence and gateways
+│       └── interface/       # web/API layer
+└── tests/                   # pytest test suite
+```
+
+This repository contains placeholder modules with minimal functionality.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "smart-host"
+version = "0.1.0"
+requires-python = ">=3.10"

--- a/src/smart_host/__init__.py
+++ b/src/smart_host/__init__.py
@@ -1,0 +1,8 @@
+"""Smart Host package placeholder."""
+
+__all__ = [
+    "domain",
+    "service",
+    "infrastructure",
+    "interface",
+]

--- a/src/smart_host/domain/__init__.py
+++ b/src/smart_host/domain/__init__.py
@@ -1,0 +1,5 @@
+"""Domain entities and logic."""
+
+from .models import Host
+
+__all__ = ["Host"]

--- a/src/smart_host/domain/models.py
+++ b/src/smart_host/domain/models.py
@@ -1,0 +1,11 @@
+"""Domain models for Smart Host."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Host:
+    """Represents a host entity."""
+
+    name: str
+    rating: float = 0.0

--- a/src/smart_host/infrastructure/__init__.py
+++ b/src/smart_host/infrastructure/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastructure layer placeholders."""
+
+from .repository import HostRepository
+
+__all__ = ["HostRepository"]

--- a/src/smart_host/infrastructure/repository.py
+++ b/src/smart_host/infrastructure/repository.py
@@ -1,0 +1,16 @@
+"""Infrastructure repository implementations."""
+
+from ..domain import Host
+
+
+class HostRepository:
+    """Placeholder in-memory host store."""
+
+    def __init__(self) -> None:
+        self._hosts: list[Host] = []
+
+    def add(self, host: Host) -> None:
+        self._hosts.append(host)
+
+    def list_hosts(self) -> list[Host]:
+        return list(self._hosts)

--- a/src/smart_host/interface/__init__.py
+++ b/src/smart_host/interface/__init__.py
@@ -1,0 +1,5 @@
+"""External interface layer."""
+
+from .api import create_app
+
+__all__ = ["create_app"]

--- a/src/smart_host/interface/api.py
+++ b/src/smart_host/interface/api.py
@@ -1,0 +1,26 @@
+"""Minimal FastAPI application."""
+
+from fastapi import FastAPI
+
+from ..service import HostService
+from ..infrastructure import HostRepository
+from ..domain import Host
+
+app = FastAPI()
+repository = HostRepository()
+service = HostService()
+
+
+@app.get("/hosts")
+def list_hosts() -> list[dict]:
+    """Return all hosts in repository."""
+    hosts = repository.list_hosts()
+    return [service.to_dict(host) for host in hosts]
+
+
+@app.post("/hosts")
+def add_host(name: str) -> dict:
+    """Add a host by name and return it."""
+    host = Host(name=name)
+    repository.add(host)
+    return service.to_dict(host)

--- a/src/smart_host/service/__init__.py
+++ b/src/smart_host/service/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer for Smart Host."""
+
+from .host_service import HostService
+
+__all__ = ["HostService"]

--- a/src/smart_host/service/host_service.py
+++ b/src/smart_host/service/host_service.py
@@ -1,0 +1,13 @@
+"""Basic service definitions."""
+
+from dataclasses import asdict
+
+from ..domain import Host
+
+
+class HostService:
+    """Service operations for managing hosts."""
+
+    def to_dict(self, host: Host) -> dict:
+        """Return a host as a serializable dictionary."""
+        return asdict(host)

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,23 @@
+"""Basic sanity test using unittest."""
+
+import sys
+from pathlib import Path
+import unittest
+
+# Ensure src package is on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from smart_host.domain import Host
+from smart_host.service import HostService
+
+
+class HostServiceTestCase(unittest.TestCase):
+    def test_host_service_to_dict(self):
+        host = Host(name="Alice")
+        service = HostService()
+        result = service.to_dict(host)
+        self.assertEqual(result, {"name": "Alice", "rating": 0.0})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create a minimal layered project structure
- add placeholder domain, service, infrastructure and interface modules
- provide a FastAPI app stub and in-memory repository
- include simple unittest for sanity check
- set up `pyproject.toml` and `.gitignore`
- document architecture in `README.md`

## Testing
- `python3 -m unittest discover -s tests -v`