### PR TITLE
Add configuration for host and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ the code lives inside the ``src`` directory you need to include it in the
 PYTHONPATH=src uvicorn smart_host.interface.api:app
 ```
 
+
+The server bind address can be adjusted with the ``HOST`` and ``PORT``
+environment variables. By default the app listens on ``127.0.0.1`` and port
+``8000``.
+
+### Environment Variables
+
+* ``HOST`` - network interface Uvicorn binds to (default ``127.0.0.1``)
+* ``PORT`` - TCP port for the web server (default ``8000``)
+
 The module also exposes a ``create_app`` function which can be used when
 embedding the application within another project.
 

--- a/src/smart_host/__main__.py
+++ b/src/smart_host/__main__.py
@@ -1,0 +1,9 @@
+"""Entry point for running the Smart Host API using Uvicorn."""
+
+from .config import HOST, PORT
+from .interface.api import app
+
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run(app, host=HOST, port=PORT)

--- a/src/smart_host/config.py
+++ b/src/smart_host/config.py
@@ -1,0 +1,9 @@
+import os
+
+"""Configuration for the Smart Host application."""
+
+HOST: str = os.environ.get("HOST", "127.0.0.1")
+"""Host interface to bind the web server to."""
+
+PORT: int = int(os.environ.get("PORT", 8000))
+"""Port the web server listens on."""


### PR DESCRIPTION
## Summary
- add `config` module reading `HOST` and `PORT` environment variables
- provide `__main__` that uses the configuration when running uvicorn
- document the new environment variables

## Testing
- `pytest -q` *(fails: command not found)*