### PR TITLE
Add database-backed repositories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "smart-host"
 version = "0.1.0"
 requires-python = ">=3.10"
+dependencies = [
+    "fastapi",
+    "sqlalchemy",
+]

--- a/scripts/generate_test_data.py
+++ b/scripts/generate_test_data.py
@@ -5,10 +5,11 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from smart_host.infrastructure import PropertyRepository
+from smart_host.infrastructure import PropertyRepository, init_db
 
 
 def main() -> None:
+    init_db()
     repo = PropertyRepository()
     aruba = repo.add_property(name="Aruba House", location="Paradera")
     repo.add_room(property_id=aruba.id, beds=2, features="Sea view", price=100.0)

--- a/src/smart_host/infrastructure/__init__.py
+++ b/src/smart_host/infrastructure/__init__.py
@@ -1,5 +1,11 @@
-"""Infrastructure layer placeholders."""
+"""Infrastructure layer using SQLAlchemy-backed repositories."""
 
 from .repository import HostRepository, PropertyRepository, BookingRepository
+from .sql import init_db
 
-__all__ = ["HostRepository", "PropertyRepository", "BookingRepository"]
+__all__ = [
+    "HostRepository",
+    "PropertyRepository",
+    "BookingRepository",
+    "init_db",
+]

--- a/src/smart_host/infrastructure/repository.py
+++ b/src/smart_host/infrastructure/repository.py
@@ -1,64 +1,135 @@
-"""Infrastructure repository implementations."""
+"""Infrastructure repository implementations backed by SQLAlchemy."""
+
+from __future__ import annotations
+
 
 from ..domain import Host, Property, Room, Booking
+from .sql import SessionLocal, init_db
+from .sql.models import (
+    HostTable,
+    PropertyTable,
+    RoomTable,
+    BookingTable,
+)
 
 
 class HostRepository:
-    """Placeholder in-memory host store."""
+    """Host persistence using the database."""
 
-    def __init__(self) -> None:
-        self._hosts: list[Host] = []
+    def __init__(self, session_factory: type[SessionLocal] = SessionLocal) -> None:
+        init_db()
+        self._session_factory = session_factory
 
     def add(self, host: Host) -> None:
-        self._hosts.append(host)
+        """Persist a host."""
+        with self._session_factory() as session:
+            db_host = HostTable(name=host.name, rating=host.rating)
+            session.add(db_host)
+            session.commit()
 
     def list_hosts(self) -> list[Host]:
-        return list(self._hosts)
+        with self._session_factory() as session:
+            hosts = session.query(HostTable).all()
+            return [Host(name=h.name, rating=h.rating) for h in hosts]
 
 
 class PropertyRepository:
-    """In-memory storage for properties and rooms."""
+    """Property and room storage using SQLAlchemy."""
 
-    def __init__(self) -> None:
-        self._properties: dict[int, Property] = {}
-        self._rooms: dict[int, Room] = {}
-        self._next_property_id = 1
-        self._next_room_id = 1
+    def __init__(self, session_factory: type[SessionLocal] = SessionLocal) -> None:
+        init_db()
+        self._session_factory = session_factory
 
     def add_property(self, name: str, location: str) -> Property:
-        prop = Property(id=self._next_property_id, name=name, location=location)
-        self._properties[prop.id] = prop
-        self._next_property_id += 1
-        return prop
+        with self._session_factory() as session:
+            prop = PropertyTable(name=name, location=location)
+            session.add(prop)
+            session.commit()
+            session.refresh(prop)
+            return Property(id=prop.id, name=prop.name, location=prop.location)
 
     def list_properties(self) -> list[Property]:
-        return list(self._properties.values())
+        with self._session_factory() as session:
+            props = session.query(PropertyTable).all()
+            return [Property(id=p.id, name=p.name, location=p.location) for p in props]
 
-    def add_room(self, property_id: int, beds: int = 1, *, features: str | None = None, price: float = 0.0) -> Room:
-        room = Room(id=self._next_room_id, property_id=property_id, beds=beds, features=features, price=price)
-        self._rooms[room.id] = room
-        self._next_room_id += 1
-        return room
+    def add_room(
+        self,
+        property_id: int,
+        beds: int = 1,
+        *,
+        features: str | None = None,
+        price: float = 0.0,
+    ) -> Room:
+        with self._session_factory() as session:
+            room = RoomTable(
+                property_id=property_id,
+                beds=beds,
+                features=features,
+                price=price,
+            )
+            session.add(room)
+            session.commit()
+            session.refresh(room)
+            return Room(
+                id=room.id,
+                property_id=room.property_id,
+                beds=room.beds,
+                features=room.features,
+                price=room.price,
+            )
 
     def list_rooms(self, property_id: int | None = None) -> list[Room]:
-        rooms = list(self._rooms.values())
-        if property_id is not None:
-            rooms = [r for r in rooms if r.property_id == property_id]
-        return rooms
+        with self._session_factory() as session:
+            query = session.query(RoomTable)
+            if property_id is not None:
+                query = query.filter_by(property_id=property_id)
+            rooms = query.all()
+            return [
+                Room(
+                    id=r.id,
+                    property_id=r.property_id,
+                    beds=r.beds,
+                    features=r.features,
+                    price=r.price,
+                )
+                for r in rooms
+            ]
 
 
 class BookingRepository:
-    """Simple booking storage."""
+    """Booking persistence using SQLAlchemy."""
 
-    def __init__(self) -> None:
-        self._bookings: dict[int, Booking] = {}
-        self._next_booking_id = 1
+    def __init__(self, session_factory: type[SessionLocal] = SessionLocal) -> None:
+        init_db()
+        self._session_factory = session_factory
 
     def add_booking(self, booking: Booking) -> Booking:
-        booking.id = self._next_booking_id
-        self._bookings[booking.id] = booking
-        self._next_booking_id += 1
-        return booking
+        with self._session_factory() as session:
+            db_booking = BookingTable(
+                room_id=booking.room_id,
+                guest_name=booking.guest_name,
+                language=booking.language,
+                check_in=booking.check_in,
+                check_out=booking.check_out,
+            )
+            session.add(db_booking)
+            session.commit()
+            session.refresh(db_booking)
+            booking.id = db_booking.id
+            return booking
 
     def list_bookings(self) -> list[Booking]:
-        return list(self._bookings.values())
+        with self._session_factory() as session:
+            bookings = session.query(BookingTable).all()
+            return [
+                Booking(
+                    id=b.id,
+                    room_id=b.room_id,
+                    guest_name=b.guest_name,
+                    language=b.language,
+                    check_in=b.check_in,
+                    check_out=b.check_out,
+                )
+                for b in bookings
+            ]

--- a/src/smart_host/infrastructure/sql/__init__.py
+++ b/src/smart_host/infrastructure/sql/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""SQLAlchemy database setup and initialization."""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, DeclarativeBase
+
+DATABASE_URL = "sqlite:///smart_host.db"
+
+engine = create_engine(
+    DATABASE_URL,
+    future=True,
+)
+
+SessionLocal = sessionmaker(bind=engine, future=True)
+
+
+class Base(DeclarativeBase):
+    """Base declarative class."""
+
+
+def init_db() -> None:
+    """Create database tables if they do not exist."""
+    from . import models  # noqa: F401 -- import models for metadata
+
+    Base.metadata.create_all(engine, checkfirst=True)

--- a/src/smart_host/infrastructure/sql/models.py
+++ b/src/smart_host/infrastructure/sql/models.py
@@ -1,0 +1,50 @@
+"""SQLAlchemy ORM models."""
+
+from datetime import date
+from sqlalchemy import Column, Date, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from . import Base
+
+
+class HostTable(Base):
+    __tablename__ = "hosts"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    rating = Column(Float, default=0.0)
+
+
+class PropertyTable(Base):
+    __tablename__ = "properties"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    location = Column(String, nullable=False)
+
+    rooms = relationship("RoomTable", back_populates="property", cascade="all, delete-orphan")
+
+
+class RoomTable(Base):
+    __tablename__ = "rooms"
+
+    id = Column(Integer, primary_key=True)
+    property_id = Column(Integer, ForeignKey("properties.id"), nullable=False)
+    beds = Column(Integer, default=1)
+    features = Column(String, nullable=True)
+    price = Column(Float, default=0.0)
+
+    property = relationship("PropertyTable", back_populates="rooms")
+
+
+class BookingTable(Base):
+    __tablename__ = "bookings"
+
+    id = Column(Integer, primary_key=True)
+    room_id = Column(Integer, ForeignKey("rooms.id"), nullable=False)
+    guest_name = Column(String, nullable=False)
+    language = Column(String, nullable=False)
+    check_in = Column(Date, nullable=False)
+    check_out = Column(Date, nullable=False)
+
+    room = relationship("RoomTable")

--- a/src/smart_host/interface/api.py
+++ b/src/smart_host/interface/api.py
@@ -8,6 +8,7 @@ from ..infrastructure import (
     HostRepository,
     PropertyRepository,
     BookingRepository,
+    init_db,
 )
 from ..domain import Host
 
@@ -16,6 +17,9 @@ def create_app() -> FastAPI:
     """Create and return the FastAPI application."""
 
     app = FastAPI()
+    # Ensure database tables exist
+    init_db()
+
     repository = HostRepository()
     prop_repo = PropertyRepository()
     booking_repo = BookingRepository()

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -10,7 +10,13 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 from smart_host.domain import Host
 from datetime import date
 from smart_host.service import HostService, PropertyService, BookingService
-from smart_host.infrastructure import PropertyRepository, BookingRepository
+from smart_host.infrastructure import (
+    PropertyRepository,
+    BookingRepository,
+    init_db,
+)
+
+init_db()
 
 
 class HostServiceTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add SQLAlchemy database setup in `infrastructure.sql`
- define SQLAlchemy ORM models
- switch repositories to use SQLAlchemy sessions
- initialize DB from FastAPI app
- wire script and tests to call `init_db`
- declare fastapi and sqlalchemy in project dependencies

## Testing
- `python tests/test_placeholder.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*