### PR TITLE
Add SQLite sample data generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ embedding the application within another project.
 
 ## Generating Sample Data
 
-Use the helper script to create a property in Paradera, Aruba with a couple of rooms:
+Run the helper script to populate ``smart_host.db`` with a few example hosts,
+one property and two rooms. The script is idempotent so it can be executed
+multiple times without duplicating entries.
 
 ```bash
 python scripts/generate_test_data.py

--- a/scripts/generate_test_data.py
+++ b/scripts/generate_test_data.py
@@ -1,22 +1,115 @@
-"""Script to generate sample data for Smart Host."""
+"""Script to populate an SQLite database with sample data."""
 
-import sys
+from __future__ import annotations
+
+import sqlite3
 from pathlib import Path
+from typing import Optional
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+DB_PATH = Path(__file__).resolve().parents[1] / "smart_host.db"
 
-from smart_host.infrastructure import PropertyRepository
+
+def init_db(conn: sqlite3.Connection) -> None:
+    """Create tables if they do not already exist."""
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS hosts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL,
+            rating REAL DEFAULT 0.0
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS properties (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL,
+            location TEXT NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS rooms (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            property_id INTEGER NOT NULL,
+            beds INTEGER DEFAULT 1,
+            features TEXT,
+            price REAL DEFAULT 0.0,
+            FOREIGN KEY(property_id) REFERENCES properties(id)
+        )
+        """
+    )
+    conn.commit()
+
+
+def add_host(conn: sqlite3.Connection, name: str, rating: float = 0.0) -> tuple[int, str, float]:
+    cur = conn.cursor()
+    cur.execute("INSERT OR IGNORE INTO hosts(name, rating) VALUES (?, ?)", (name, rating))
+    conn.commit()
+    cur.execute("SELECT id, name, rating FROM hosts WHERE name=?", (name,))
+    return cur.fetchone()
+
+
+def add_property(conn: sqlite3.Connection, name: str, location: str) -> tuple[int, str, str]:
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT OR IGNORE INTO properties(name, location) VALUES (?, ?)",
+        (name, location),
+    )
+    conn.commit()
+    cur.execute("SELECT id, name, location FROM properties WHERE name=?", (name,))
+    return cur.fetchone()
+
+
+def add_room(
+    conn: sqlite3.Connection,
+    property_id: int,
+    beds: int = 1,
+    *,
+    features: Optional[str] = None,
+    price: float = 0.0,
+) -> tuple[int, int, int, Optional[str], float]:
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT id FROM rooms
+        WHERE property_id=? AND beds=? AND features IS ? AND price=?
+        """,
+        (property_id, beds, features, price),
+    )
+    row = cur.fetchone()
+    if row is None:
+        cur.execute(
+            "INSERT INTO rooms(property_id, beds, features, price) VALUES (?, ?, ?, ?)",
+            (property_id, beds, features, price),
+        )
+        conn.commit()
+        room_id = cur.lastrowid
+    else:
+        room_id = row[0]
+    cur.execute("SELECT * FROM rooms WHERE id=?", (room_id,))
+    return cur.fetchone()
 
 
 def main() -> None:
-    repo = PropertyRepository()
-    aruba = repo.add_property(name="Aruba House", location="Paradera")
-    repo.add_room(property_id=aruba.id, beds=2, features="Sea view", price=100.0)
-    repo.add_room(property_id=aruba.id, beds=1, features="Garden access", price=80.0)
-    for prop in repo.list_properties():
-        print(prop)
-    for room in repo.list_rooms(aruba.id):
-        print(room)
+    conn = sqlite3.connect(DB_PATH)
+    init_db(conn)
+
+    alice = add_host(conn, "Alice", rating=4.5)
+    bob = add_host(conn, "Bob", rating=4.8)
+    print(f"Hosts: {alice}, {bob}")
+
+    aruba = add_property(conn, "Aruba House", "Paradera")
+    room1 = add_room(conn, aruba[0], beds=2, features="Sea view", price=100.0)
+    room2 = add_room(conn, aruba[0], beds=1, features="Garden access", price=80.0)
+
+    print("Property:", aruba)
+    print("Rooms:", room1, room2)
+
+    conn.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- create SQLite tables and seed hosts, properties, and rooms
- make the data generation idempotent
- document the helper script in the README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*