### PR TITLE
Add SQLite repos and integration tests

### DIFF
--- a/src/smart_host/infrastructure/__init__.py
+++ b/src/smart_host/infrastructure/__init__.py
@@ -1,5 +1,17 @@
 """Infrastructure layer placeholders."""
 
 from .repository import HostRepository, PropertyRepository, BookingRepository
+from .sqlite_repository import (
+    SqliteHostRepository,
+    SqlitePropertyRepository,
+    SqliteBookingRepository,
+)
 
-__all__ = ["HostRepository", "PropertyRepository", "BookingRepository"]
+__all__ = [
+    "HostRepository",
+    "PropertyRepository",
+    "BookingRepository",
+    "SqliteHostRepository",
+    "SqlitePropertyRepository",
+    "SqliteBookingRepository",
+]

--- a/src/smart_host/infrastructure/sqlite_repository.py
+++ b/src/smart_host/infrastructure/sqlite_repository.py
@@ -1,0 +1,160 @@
+import sqlite3
+from datetime import date
+
+from ..domain import Host, Property, Room, Booking
+
+
+class SqliteHostRepository:
+    """SQLite-backed repository for hosts."""
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        self._conn = sqlite3.connect(db_path)
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS hosts (name TEXT, rating REAL)"
+        )
+        self._conn.commit()
+
+    def add(self, host: Host) -> None:
+        self._conn.execute(
+            "INSERT INTO hosts (name, rating) VALUES (?, ?)",
+            (host.name, host.rating),
+        )
+        self._conn.commit()
+
+    def list_hosts(self) -> list[Host]:
+        cur = self._conn.execute("SELECT name, rating FROM hosts")
+        return [Host(name=row[0], rating=row[1]) for row in cur.fetchall()]
+
+
+class SqlitePropertyRepository:
+    """SQLite-backed repository for properties and rooms."""
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        self._conn = sqlite3.connect(db_path)
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS properties (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT,
+                location TEXT
+            )
+            """
+        )
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS rooms (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                property_id INTEGER,
+                beds INTEGER,
+                features TEXT,
+                price REAL
+            )
+            """
+        )
+        self._conn.commit()
+
+    def add_property(self, name: str, location: str) -> Property:
+        cur = self._conn.execute(
+            "INSERT INTO properties (name, location) VALUES (?, ?)",
+            (name, location),
+        )
+        self._conn.commit()
+        return Property(id=cur.lastrowid, name=name, location=location)
+
+    def list_properties(self) -> list[Property]:
+        cur = self._conn.execute("SELECT id, name, location FROM properties")
+        return [
+            Property(id=row[0], name=row[1], location=row[2])
+            for row in cur.fetchall()
+        ]
+
+    def add_room(
+        self,
+        property_id: int,
+        beds: int = 1,
+        *,
+        features: str | None = None,
+        price: float = 0.0,
+    ) -> Room:
+        cur = self._conn.execute(
+            "INSERT INTO rooms (property_id, beds, features, price) VALUES (?, ?, ?, ?)",
+            (property_id, beds, features, price),
+        )
+        self._conn.commit()
+        return Room(
+            id=cur.lastrowid,
+            property_id=property_id,
+            beds=beds,
+            features=features,
+            price=price,
+        )
+
+    def list_rooms(self, property_id: int | None = None) -> list[Room]:
+        query = "SELECT id, property_id, beds, features, price FROM rooms"
+        params: tuple = ()
+        if property_id is not None:
+            query += " WHERE property_id = ?"
+            params = (property_id,)
+        cur = self._conn.execute(query, params)
+        return [
+            Room(
+                id=row[0],
+                property_id=row[1],
+                beds=row[2],
+                features=row[3],
+                price=row[4],
+            )
+            for row in cur.fetchall()
+        ]
+
+
+class SqliteBookingRepository:
+    """SQLite-backed repository for bookings."""
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        self._conn = sqlite3.connect(db_path)
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bookings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                room_id INTEGER,
+                guest_name TEXT,
+                language TEXT,
+                check_in TEXT,
+                check_out TEXT
+            )
+            """
+        )
+        self._conn.commit()
+
+    def add_booking(self, booking: Booking) -> Booking:
+        cur = self._conn.execute(
+            "INSERT INTO bookings (room_id, guest_name, language, check_in, check_out) VALUES (?, ?, ?, ?, ?)",
+            (
+                booking.room_id,
+                booking.guest_name,
+                booking.language,
+                booking.check_in.isoformat(),
+                booking.check_out.isoformat(),
+            ),
+        )
+        self._conn.commit()
+        booking.id = cur.lastrowid
+        return booking
+
+    def list_bookings(self) -> list[Booking]:
+        cur = self._conn.execute(
+            "SELECT id, room_id, guest_name, language, check_in, check_out FROM bookings"
+        )
+        rows = cur.fetchall()
+        return [
+            Booking(
+                id=row[0],
+                room_id=row[1],
+                guest_name=row[2],
+                language=row[3],
+                check_in=date.fromisoformat(row[4]),
+                check_out=date.fromisoformat(row[5]),
+            )
+            for row in rows
+        ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,85 @@
+"""Integration tests for FastAPI endpoints."""
+
+import sys
+from pathlib import Path
+from datetime import date
+import unittest
+
+# Ensure src package is on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+try:
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover - dependency missing
+    TestClient = None
+from smart_host.interface.api import create_app
+
+
+class ApiIntegrationTestCase(unittest.TestCase):
+    def setUp(self):
+        if TestClient is None:
+            self.skipTest("fastapi.testclient not available")
+        self.client = TestClient(create_app())
+
+    def test_hosts_endpoints(self):
+        # Initially empty
+        response = self.client.get("/hosts")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+        # Add a host
+        response = self.client.post("/hosts", params={"name": "Alice"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["name"], "Alice")
+
+        # List hosts
+        response = self.client.get("/hosts")
+        self.assertEqual(len(response.json()), 1)
+
+    def test_property_and_room_endpoints(self):
+        # Add property
+        resp = self.client.post("/properties", params={"name": "Beach", "location": "Aruba"})
+        self.assertEqual(resp.status_code, 200)
+        prop_id = resp.json()["id"]
+
+        # List properties
+        resp = self.client.get("/properties")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.json()), 1)
+
+        # Add room
+        resp = self.client.post(f"/properties/{prop_id}/rooms", params={"beds": 2})
+        self.assertEqual(resp.status_code, 200)
+        room_id = resp.json()["id"]
+
+        # List rooms
+        resp = self.client.get(f"/properties/{prop_id}/rooms")
+        self.assertEqual(len(resp.json()), 1)
+        self.assertEqual(resp.json()[0]["id"], room_id)
+
+    def test_booking_endpoints(self):
+        # Add property and room for booking
+        prop = self.client.post("/properties", params={"name": "House", "location": "Aruba"}).json()
+        room = self.client.post(f"/properties/{prop['id']}/rooms").json()
+
+        # Create booking
+        payload = {
+            "room_id": room["id"],
+            "guest_name": "Bob",
+            "language": "en",
+            "check_in": date(2024, 1, 1).isoformat(),
+            "check_out": date(2024, 1, 5).isoformat(),
+        }
+        resp = self.client.post("/bookings", params=payload)
+        self.assertEqual(resp.status_code, 200)
+        booking_id = resp.json()["id"]
+
+        # List bookings
+        resp = self.client.get("/bookings")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.json()), 1)
+        self.assertEqual(resp.json()[0]["id"], booking_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sqlite_repositories.py
+++ b/tests/test_sqlite_repositories.py
@@ -1,0 +1,67 @@
+"""Unit tests for SQLite-backed repositories."""
+
+import sys
+from pathlib import Path
+from datetime import date
+import unittest
+
+# Ensure src package is on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from smart_host.domain import Host, Booking
+from smart_host.infrastructure import (
+    SqliteHostRepository,
+    SqlitePropertyRepository,
+    SqliteBookingRepository,
+)
+
+
+class SqliteHostRepositoryTestCase(unittest.TestCase):
+    def setUp(self):
+        self.repo = SqliteHostRepository()
+
+    def test_add_and_list_hosts(self):
+        host = Host(name="Alice")
+        self.repo.add(host)
+        hosts = self.repo.list_hosts()
+        self.assertEqual(len(hosts), 1)
+        self.assertEqual(hosts[0].name, "Alice")
+
+
+class SqlitePropertyRepositoryTestCase(unittest.TestCase):
+    def setUp(self):
+        self.repo = SqlitePropertyRepository()
+
+    def test_property_crud(self):
+        prop = self.repo.add_property(name="Beach House", location="Aruba")
+        props = self.repo.list_properties()
+        self.assertEqual(props[0].name, "Beach House")
+        room = self.repo.add_room(prop.id, beds=2, features="AC", price=99.0)
+        rooms = self.repo.list_rooms(prop.id)
+        self.assertEqual(len(rooms), 1)
+        self.assertEqual(rooms[0].id, room.id)
+        self.assertEqual(rooms[0].beds, 2)
+
+
+class SqliteBookingRepositoryTestCase(unittest.TestCase):
+    def setUp(self):
+        self.repo = SqliteBookingRepository()
+
+    def test_add_and_list_bookings(self):
+        self.repo.add_booking(
+            booking=Booking(
+                id=0,
+                room_id=1,
+                guest_name="Bob",
+                language="en",
+                check_in=date(2024, 1, 1),
+                check_out=date(2024, 1, 5),
+            )
+        )
+        bookings = self.repo.list_bookings()
+        self.assertEqual(len(bookings), 1)
+        self.assertEqual(bookings[0].guest_name, "Bob")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement SQLite-backed repositories
- expose them in the infrastructure package
- add unit tests for the SQLite repositories
- add integration tests for each API endpoint with graceful skip if `fastapi.testclient` is missing

## Testing
- `python -m unittest discover -v`