### PR TITLE
Add pinned dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ smart-host/
 
 This repository contains placeholder modules with minimal functionality.
 
+## Dependency Management
+
+Project dependencies are listed in two places:
+
+* `pyproject.toml` - used when packaging the library or installing via tools
+  that support PEP 621.
+* `requirements.txt` - provides pinned versions for local development and CI
+  environments.
+
+The two files contain the same base dependencies, but `requirements.txt` pins
+exact versions to ensure reproducible installs.
+
 ## Running the API
 
 Install dependencies and start the FastAPI app (example using Uvicorn). Since

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,5 @@ requires-python = ">=3.10"
 dependencies = [
     "fastapi",
     "sqlalchemy",
+    "uvicorn==0.27.0.post1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.97.0
 uvicorn==0.27.0.post1
+sqlalchemy==2.0.25


### PR DESCRIPTION
## Summary
- pin `sqlalchemy` in `requirements.txt`
- pin `uvicorn` in `pyproject.toml`
- document how `pyproject.toml` and `requirements.txt` are used

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*