### PR TITLE
Add chat template and route

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ The server bind address can be adjusted with the ``HOST`` and ``PORT``
 environment variables. By default the app listens on ``127.0.0.1`` and port
 ``8000``.
 
+Once the server is running open ``http://127.0.0.1:8000/chat`` in your browser
+to view the minimal chat interface.
+
 ### Environment Variables
 
 * ``HOST`` - network interface Uvicorn binds to (default ``127.0.0.1``)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,6 @@ requires-python = ">=3.10"
 dependencies = [
     "fastapi",
     "sqlalchemy",
+    "jinja2",
     "uvicorn==0.27.0.post1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.97.0
 uvicorn==0.27.0.post1
 sqlalchemy==2.0.25
+jinja2==3.1.2

--- a/src/smart_host/interface/api.py
+++ b/src/smart_host/interface/api.py
@@ -1,6 +1,18 @@
 """Minimal FastAPI application."""
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from pathlib import Path
+
+try:  # Optional dependency for test environment
+    from fastapi.templating import Jinja2Templates
+
+    templates = Jinja2Templates(
+        directory=str(Path(__file__).resolve().parent / "templates")
+    )
+except Exception:  # pragma: nocover
+    Jinja2Templates = None  # type: ignore
+    templates = None
 from datetime import date
 
 from ..service import HostService, PropertyService, BookingService
@@ -98,6 +110,14 @@ def create_app() -> FastAPI:
         """Return all bookings."""
         bookings = booking_service.list_bookings()
         return [booking_service.to_dict(b) for b in bookings]
+
+    @app.get("/chat", response_class=HTMLResponse)
+    def chat(request: Request):
+        """Render simple chat interface."""
+        if templates is not None:
+            return templates.TemplateResponse("chat.html", {"request": request})
+        html = (Path(__file__).resolve().parent / "templates" / "chat.html").read_text()
+        return HTMLResponse(html)
 
     return app
 

--- a/src/smart_host/interface/templates/chat.html
+++ b/src/smart_host/interface/templates/chat.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Chat</title>
+    <style>
+        body { font-family: sans-serif; margin: 2em auto; max-width: 600px; }
+        .row { display: flex; gap: 0.5em; }
+        input[type=text] { flex: 1; padding: 0.5em; }
+        button { padding: 0.5em 1em; }
+    </style>
+</head>
+<body>
+    <div class="row">
+        <input id="message" type="text" placeholder="Say something...">
+        <button id="mic">🎤</button>
+        <button id="send">Send</button>
+    </div>
+</body>
+</html>

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+import unittest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+try:
+    from fastapi.testclient import TestClient
+except Exception:  # httpx or fastapi might be missing
+    TestClient = None  # type: ignore
+
+import types
+
+fake_infra = types.ModuleType("smart_host.infrastructure")
+fake_infra.HostRepository = lambda *a, **k: None
+fake_infra.PropertyRepository = lambda *a, **k: None
+fake_infra.BookingRepository = lambda *a, **k: None
+fake_infra.init_db = lambda: None
+sys.modules["smart_host.infrastructure"] = fake_infra
+
+from smart_host.interface.api import create_app
+
+
+class ChatRouteTestCase(unittest.TestCase):
+    def setUp(self):
+        if TestClient is None:
+            self.skipTest("TestClient unavailable")
+        self.client = TestClient(create_app())
+
+    def test_chat_route(self):
+        resp = self.client.get("/chat")
+        self.assertEqual(resp.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -27,9 +27,16 @@ class FakePropertyRepository:
         return list(self.properties)
 
     def add_room(
-        self, property_id: int, beds: int = 1, *, features: str | None = None, price: float = 0.0
+        self,
+        property_id: int,
+        beds: int = 1,
+        *,
+        features: str | None = None,
+        price: float = 0.0,
     ) -> Room:
-        return Room(id=1, property_id=property_id, beds=beds, features=features, price=price)
+        return Room(
+            id=1, property_id=property_id, beds=beds, features=features, price=price
+        )
 
     def list_rooms(self, property_id: int) -> list[Room]:
         return []
@@ -58,6 +65,8 @@ fake_infra.BookingRepository = FakeBookingRepository
 fake_infra.HostRepository = lambda *a, **k: None
 fake_infra.init_db = lambda: None
 sys.modules["smart_host.infrastructure"] = fake_infra
+
+PropertyRepository = FakePropertyRepository
 
 from smart_host.service import HostService, PropertyService, BookingService
 
@@ -122,7 +131,9 @@ class APIBookingValidationTestCase(unittest.TestCase):
         app = create_app()
 
         create_booking = next(
-            route.endpoint for route in app.router.routes if route.path == "/bookings" and "POST" in route.methods
+            route.endpoint
+            for route in app.router.routes
+            if route.path == "/bookings" and "POST" in route.methods
         )
 
         with self.assertRaises(HTTPException) as ctx:
@@ -135,6 +146,7 @@ class APIBookingValidationTestCase(unittest.TestCase):
             )
 
         self.assertEqual(ctx.exception.status_code, 400)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `jinja2` to dependencies
- create a simple HTML chat template
- serve template via new `/chat` endpoint
- document how to access the chat page
- test the new route
- fix placeholder tests for missing repo class

## Testing
- `python -m unittest`